### PR TITLE
New Feature: complete exts list for R extensions

### DIFF
--- a/easybuild/framework/easyconfig/exts_tools.py
+++ b/easybuild/framework/easyconfig/exts_tools.py
@@ -558,7 +558,7 @@ def _get_completed_R_exts_list(exts_list, bioconductor_version=None, installed_e
         # get the values of the extension
         ext_name, ext_version, ext_options = _get_extension_values(ext)
 
-        print_msg(f"\t{ext_name:<{PKG_NAME_OFFSET}} v{('_' if ext_version is None else ext_version):<{PKG_VERSION_OFFSET}}}", prefix=False, log=_log)
+        print_msg(f"\t{ext_name:<{PKG_NAME_OFFSET}} v{('_' if ext_version is None else ext_version):<{PKG_VERSION_OFFSET}}", prefix=False, log=_log)
 
         # get metadata of the extension
         metadata = _get_pkg_metadata(pkg_class="RPackage",

--- a/easybuild/framework/easyconfig/exts_tools.py
+++ b/easybuild/framework/easyconfig/exts_tools.py
@@ -1163,6 +1163,8 @@ def _get_deps_and_exts(ec_name):
     # search for the corresponding EasyConfig file
     easyconfigs = search_easyconfigs(ec_name, print_result=False)
 
+    # TODO: Change this so it takes the exactly filename using os basepath functionality
+
     # if easyconfig files were found, then process them
     if not easyconfigs:
         print_warning("No EasyConfig file found for dependency %s", ec_name)

--- a/easybuild/framework/easyconfig/exts_tools.py
+++ b/easybuild/framework/easyconfig/exts_tools.py
@@ -1083,8 +1083,9 @@ def complete_exts_list(ecs):
     for ec in ecs:
 
         # welcome message
-        print()
-        print_msg("COMPLETING EASYCONFIG %s" % ec['spec'], log=_log)
+        print_msg("\nCOMPLETE EASYCONFIG EXTENSIONS", prefix=False, log=_log)
+
+        print_msg("Easyconfig: %s" % ec['spec'], log=_log)
 
         # get the extension list
         print_msg("Getting extension list...", log=_log)
@@ -1095,8 +1096,9 @@ def complete_exts_list(ecs):
         exts_defaultclass = _get_exts_list_class(ec)
 
         # get the extensions installed by dependencies
-        print_msg("Getting installed extensions...", log=_log)
+        print_msg("Getting extensions installed by dependencies or build dependencies...", log=_log)
         installed_exts = _get_installed_exts(ec)
+        print_msg(f"\tInstalled extensions found: {len(installed_exts)}", prefix=False, log=_log)
 
         # get the Bioconductor version
         print_msg("Getting Bioconductor version (if any)...", log=_log)
@@ -1119,4 +1121,4 @@ def complete_exts_list(ecs):
         write_file(ec['spec'], updated_easyconfig)
 
         # success message
-        print_msg('EASYCONFIG SUCCESSFULLY COMPLETED!\n', log=_log)
+        print_msg('EASYCONFIG SUCCESSFULLY COMPLETED!\n', prefix=False, log=_log)

--- a/easybuild/framework/easyconfig/exts_tools.py
+++ b/easybuild/framework/easyconfig/exts_tools.py
@@ -462,7 +462,7 @@ def _get_R_extension_dependencies(extension, bioconductor_version=None, exts_lis
                 if ext[0].lower() == dep_name.lower():
                     is_in_exts_list = True
                     print_msg(
-                        f"  {dep_name:<{PKG_NAME_OFFSET}} is in the original exts_list. RECOMMENDATION: Consider removing {dep_name} from the original exts_list", prefix=False, log=_log)
+                        f"\t{dep_name:<{PKG_NAME_OFFSET}} is in the original exts_list. RECOMMENDATION: Consider removing {dep_name} from the original exts_list", prefix=False, log=_log)
                     break
             
             # if the dependency is in the exts_list, then skip
@@ -474,7 +474,7 @@ def _get_R_extension_dependencies(extension, bioconductor_version=None, exts_lis
             for exclude_ext in EXCLUDE_R_LIST:
                 if exclude_ext.lower() == dep_name.lower():
                     is_excluded = True
-                    print_msg(f"  {dep_name:<{PKG_NAME_OFFSET}} is blacklisted", prefix=False, log=_log)
+                    print_msg(f"\t{dep_name:<{PKG_NAME_OFFSET}} is blacklisted", prefix=False, log=_log)
                     continue
 
             # if the dependency is excluded, then skip
@@ -488,14 +488,14 @@ def _get_R_extension_dependencies(extension, bioconductor_version=None, exts_lis
                 if inst_ext_name.lower() == dep_name.lower():
                     is_installed = True
                     print_msg(
-                        f"  {dep_name:<{PKG_NAME_OFFSET}} installed by dependency: {inst_ext_options['easyconfig_path']}", prefix=False, log=_log)
+                        f"\t{dep_name:<{PKG_NAME_OFFSET}} installed by dependency: {inst_ext_options['easyconfig_path']}", prefix=False, log=_log)
                     break
 
             # if the dependency is already installed, then skip
             if is_installed:
                 continue
 
-            print_msg(f"  {dep_name:<{PKG_NAME_OFFSET}} added as dependency", prefix=False, log=_log)
+            print_msg(f"\t{dep_name:<{PKG_NAME_OFFSET}} added as dependency", prefix=False, log=_log)
             
             # build the metadata dependency as extension getting the last version
             dep_name = {'name': dep_name, 'version': None, 'options': {}}
@@ -558,7 +558,7 @@ def _get_completed_R_exts_list(exts_list, bioconductor_version=None, installed_e
         # get the values of the extension
         ext_name, ext_version, ext_options = _get_extension_values(ext)
 
-        print_msg(f"  {ext_name:<{PKG_NAME_OFFSET}} v{ext_version:<{PKG_VERSION_OFFSET}}", prefix=False, log=_log)
+        print_msg(f"\t{ext_name:<{PKG_NAME_OFFSET}} v{('_' if ext_version is None else ext_version):<{PKG_VERSION_OFFSET}}}", prefix=False, log=_log)
 
         # get metadata of the extension
         metadata = _get_pkg_metadata(pkg_class="RPackage",

--- a/easybuild/framework/easyconfig/exts_tools.py
+++ b/easybuild/framework/easyconfig/exts_tools.py
@@ -1217,15 +1217,15 @@ def complete_exts_list(ecs):
         exts_defaultclass = _get_exts_list_class(ec)
         print_msg(f"{exts_defaultclass}", prefix=False, log=_log)
 
-        # get the extensions installed by dependencies
-        print_msg("Getting extensions installed by dependencies or build dependencies...", log=_log)
-        installed_exts = _get_installed_exts(ec)
-        print_msg(f"\tInstalled extensions found: {len(installed_exts)}", prefix=False, log=_log)
-
         # get the Bioconductor version
         print_msg("Getting Bioconductor version: ", newline=False, log=_log)
         bioconductor_version = _get_bioconductor_version(ec)
         print_msg(f"{'local_biocver not set. Bioconductor packages will not be considered' if not bioconductor_version else bioconductor_version}", prefix=False, log=_log)
+
+        # get the extensions installed by dependencies
+        print_msg("Getting extensions installed by dependencies or build dependencies...", log=_log)
+        installed_exts = _get_installed_exts(ec)
+        print_msg(f"\tInstalled extensions found: {len(installed_exts)}", prefix=False, log=_log)
 
         # get a new exts_list with all extensions to their latest version.
         print_msg("Searching for dependencies of the extensions...", log=_log)

--- a/easybuild/framework/easyconfig/exts_tools.py
+++ b/easybuild/framework/easyconfig/exts_tools.py
@@ -510,6 +510,9 @@ def _get_R_extension_dependencies(extension, bioconductor_version=None, exts_lis
             # clean the dependency values
             dep_name, _, _ = _get_clean_pkg_values(dep_name)
 
+            # append the actual dependency to the list
+            dependencies.append((dep_name, ext_name))
+
             # check if the dependency already processed
             is_processed = False
             for proc_ext in processed_exts:
@@ -565,9 +568,6 @@ def _get_R_extension_dependencies(extension, bioconductor_version=None, exts_lis
 
             # append the recursive found dependencies to the list
             dependencies.extend(deps)
-
-            # append the actual dependency to the list
-            dependencies.append((dep_name, ext_name))
 
     return dependencies
 

--- a/easybuild/framework/easyconfig/exts_tools.py
+++ b/easybuild/framework/easyconfig/exts_tools.py
@@ -63,9 +63,9 @@ INFO_OFFSET = 20
 
 # List of packages to exclude from the dependencies
 EXCLUDE_R_LIST = ['R', 'base', 'compiler', 'datasets', 'graphics',
-                'grDevices', 'grid', 'methods', 'parallel',
-                'splines', 'stats', 'stats4', 'tcltk', 'tools',
-                'utils', 'MASS']
+                  'grDevices', 'grid', 'methods', 'parallel',
+                  'splines', 'stats', 'stats4', 'tcltk', 'tools',
+                  'utils', 'MASS']
 
 # Global variable to store Bioconductor packages
 bioc_packages_cache = None
@@ -361,7 +361,7 @@ def _get_clean_pkg_values(pkg_name=None, pkg_version=None, pkg_options=None):
     clean_name, clean_version, clean_options = pkg_name, pkg_version, pkg_options
 
     # clean the name
-    if pkg_name: 
+    if pkg_name:
         # Regular expression pattern to match versions like 'RSQLite (>= 2.0)'
         pattern = r'^(?P<name>[^\s]+) \((?P<info>.+)\)$'
         match = re.match(pattern, pkg_name)
@@ -378,13 +378,13 @@ def _get_clean_pkg_values(pkg_name=None, pkg_version=None, pkg_options=None):
     if pkg_version:
         # allow only alphanumeric characters in the version
         allowed_version_chars = r'[^0-9><=!*. \-]'
-        
+
         # remove any non-alphanumeric characters from the version
         clean_version = re.sub(allowed_version_chars, '', pkg_version)
 
         # remove any new line characters from the version
         clean_version = clean_version.replace('\n', '')
-    
+
     # clean the options
     if pkg_options:
         checksum = pkg_options['checksums']
@@ -412,7 +412,7 @@ def _get_R_extension_dependencies(extension, bioconductor_version=None, exts_lis
     if not extension:
         raise EasyBuildError("No extension provided to get the dependencies from")
 
-    # init variables 
+    # init variables
     dependencies = []
 
     # get the values of the extension
@@ -465,7 +465,7 @@ def _get_R_extension_dependencies(extension, bioconductor_version=None, exts_lis
                     print_msg(
                         f"\t{dep_name:<{PKG_NAME_OFFSET}} is in the original exts_list. RECOMMENDATION: Consider removing {dep_name} from the original exts_list", prefix=False, log=_log)
                     break
-            
+
             # if the dependency is in the exts_list, then skip
             if is_in_exts_list:
                 continue
@@ -497,12 +497,16 @@ def _get_R_extension_dependencies(extension, bioconductor_version=None, exts_lis
                 continue
 
             print_msg(f"\t{dep_name:<{PKG_NAME_OFFSET}} added as dependency", prefix=False, log=_log)
-            
+
             # build the metadata dependency as extension getting the last version
             dep_name = {'name': dep_name, 'version': None, 'options': {}}
 
             # recursively get dependencies of dependency
-            deps = _get_R_extension_dependencies(dep_name, bioconductor_version, processed_exts)
+            deps = _get_R_extension_dependencies(dep_name,
+                                                 bioconductor_version,
+                                                 exts_list,
+                                                 installed_exts,
+                                                 processed_exts)
 
             # append the dependencies to the list
             dependencies.extend(deps)
@@ -536,6 +540,7 @@ def _print_extension(extension):
     print_msg(
         f"\t{name:<{PKG_NAME_OFFSET}} v{version:<{PKG_VERSION_OFFSET}} checksum: {checksum:<{CHECKSUM_OFFSET}}", prefix=False, log=_log)
 
+
 def _get_completed_R_exts_list(exts_list, bioconductor_version=None, installed_exts=[]):
     """
     Complete the R extensions list with its dependencies in correct order.
@@ -566,7 +571,7 @@ def _get_completed_R_exts_list(exts_list, bioconductor_version=None, installed_e
 
         # store the dependencies in the complete list
         completed_exts_list.extend(dependencies)
-        
+
         # store the extension in the complete list
         completed_exts_list.append({"name": ext_name, "version": ext_version, "options": ext_options})
 
@@ -605,9 +610,9 @@ def _get_completed_R_exts_list(exts_list, bioconductor_version=None, installed_e
 
         # get metadata of the extension
         metadata = _get_pkg_metadata(pkg_class="RPackage",
-                                    pkg_name=ext_name,
-                                    pkg_version=ext_version,
-                                    bioc_version=bioconductor_version)
+                                     pkg_name=ext_name,
+                                     pkg_version=ext_version,
+                                     bioc_version=bioconductor_version)
 
         # process the metadata, format it as an extension, and store it
         if metadata:
@@ -643,13 +648,13 @@ def _get_completed_exts_list(exts_list, exts_defaultclass, installed_exts, bioco
         raise EasyBuildError("No exts_defaultclass provided for completing")
 
     if exts_defaultclass == "RPackage":
-        completed_exts_list =  _get_completed_R_exts_list(exts_list, bioconductor_version, installed_exts)
+        completed_exts_list = _get_completed_R_exts_list(exts_list, bioconductor_version, installed_exts)
     elif exts_defaultclass == "PythonPackage":
         # _complete_python_exts_list(exts_list, installed_exts)
         raise EasyBuildError("--complete-exts-list not implemented for PythonPackage yet")
     else:
         raise EasyBuildError("exts_defaultclass %s not supported" % exts_defaultclass)
-    
+
     return completed_exts_list
 
 
@@ -700,9 +705,9 @@ def _get_updated_exts_list(exts_list, exts_defaultclass, bioconductor_version=No
 
         # get metadata of the latest version of the extension
         metadata = _get_pkg_metadata(pkg_class=exts_defaultclass,
-                                    pkg_name=ext_name,
-                                    pkg_version=None,
-                                    bioc_version=bioconductor_version)
+                                     pkg_name=ext_name,
+                                     pkg_version=None,
+                                     bioc_version=bioconductor_version)
 
         if metadata:
             # process the metadata and format it as an extension
@@ -804,6 +809,7 @@ def _get_dependencies(ec):
 
     app: EasyBlock = get_easyblock_instance(ec)
     return app.cfg.dependencies()
+
 
 def _get_exts_list(ec):
     """
@@ -966,7 +972,7 @@ def _get_installed_exts(ec, ec_dep=None, processed_deps=[]):
         raise EasyBuildError("No EasyConfig instance provided to retrieve extensions from")
 
     print_msg(f"\r\tDependencies processed: {len(processed_deps)}", newline=False, prefix=False, log=_log)
-    
+
     # init variable to store the installed extensions
     installed_exts = []
 
@@ -1031,8 +1037,9 @@ def _get_installed_exts(ec, ec_dep=None, processed_deps=[]):
 
     # restore the original value of the terse option
     update_build_option('terse', terse)
-    
+
     return installed_exts
+
 
 def update_exts_list(ecs):
     """
@@ -1147,7 +1154,8 @@ def complete_exts_list(ecs):
 
         # get a new exts_list with all extensions to their latest version.
         print_msg("Searching for dependencies of the extensions...", log=_log)
-        completed_exts_list = _get_completed_exts_list(exts_list, exts_defaultclass, installed_exts, bioconductor_version)
+        completed_exts_list = _get_completed_exts_list(
+            exts_list, exts_defaultclass, installed_exts, bioconductor_version)
 
         # get new easyconfig file with the updated extensions list
         print_msg('Updating Easyconfig instance with completed exts_list...', log=_log)

--- a/easybuild/framework/easyconfig/exts_tools.py
+++ b/easybuild/framework/easyconfig/exts_tools.py
@@ -75,12 +75,12 @@ bioc_packages_cache = None
 _log = fancylogger.getLogger('easyblock')
 
 
-def _get_dependencies_graph(edges, nodes):
+def _create_graph(edges, nodes):
     """
     Create a graph from the given edges and nodes.
     
-    :param edges: list of edges (from_node, to_node) where to_node depends on from_node
-    :param nodes: list of standalone nodes
+    :param edges: list of edges
+    :param nodes: list of nodes
     
     :return: graph
     """
@@ -91,17 +91,18 @@ def _get_dependencies_graph(edges, nodes):
     for from_node, to_node in edges:
         if from_node not in graph["nodes"]:
             graph["nodes"].add(from_node)
+            graph["edges"][from_node] = []
         if to_node not in graph["nodes"]:
             graph["nodes"].add(to_node)
-        graph["edges"][from_node] = to_node
+            graph["edges"][to_node] = []
+        graph["edges"][from_node].append(to_node)
     
     # Add standalone nodes
     if nodes:
         for node in nodes:
             if node not in graph["nodes"]:
                 graph["nodes"].add(node)
-            if node not in graph["edges"]:
-                graph["edges"][node] = None
+                graph["edges"][node] = []
 
     return graph
 
@@ -115,26 +116,26 @@ def _topological_sort(graph):
     :return: sorted list of the graph
     """
 
+    # calculate in-degree of each node
     in_degree = {node: 0 for node in graph["nodes"]}
-    
-    # Calculate in-degrees
-    for from_node, to_node in graph["edges"].items():
-        if to_node is not None:
+    for from_node in graph["edges"]:
+        for to_node in graph["edges"][from_node]:
             in_degree[to_node] += 1
 
-    # Initialize queue with nodes that have in-degree of 0
+    # initialize queue with nodes that have in-degree 0
     queue = deque([node for node in graph["nodes"] if in_degree[node] == 0])
     sorted_list = []
 
+    # perform topological sort
     while queue:
         node = queue.popleft()
         sorted_list.append(node)
-        if graph["edges"][node] is not None:
-            to_node = graph["edges"][node]
+        for to_node in graph["edges"][node]:
             in_degree[to_node] -= 1
             if in_degree[to_node] == 0:
                 queue.append(to_node)
 
+    # check if the graph has at least one cycle
     if len(sorted_list) == len(graph["nodes"]):
         return sorted_list
     else:
@@ -685,12 +686,12 @@ def _get_R_dependency_graph(exts_list, bioconductor_version=None, installed_exts
         # append the dependencies to the list of edges
         edges.extend(dependencies)
 
-    dep_graph = _get_dependencies_graph(edges, nodes)
+    graph = _create_graph(edges, nodes)
 
     # aesthetic terminal print
     print()
 
-    return dep_graph
+    return graph
 
 
 def _get_completed_exts_list(exts_list, exts_defaultclass, installed_exts, bioconductor_version=None):

--- a/easybuild/framework/easyconfig/exts_tools.py
+++ b/easybuild/framework/easyconfig/exts_tools.py
@@ -522,9 +522,9 @@ def _get_R_extension_dependencies(ext, bioconductor_version=None, exclude_list=[
                 if excluded_name.lower() == dep_name.lower():
                     ec_path = excluded_options.get('easyconfig_path', None)
                     if ec_path:
-                        print_msg(f"\t{dep_name:<{PKG_NAME_OFFSET}} is already installed by '{ec_path}'", prefix=False, log=_log)
+                        print_msg(f"{' ' * 4 * depth}{dep_name:<{PKG_NAME_OFFSET}} is already installed by '{ec_path}'", prefix=False, log=_log)
                     else:
-                        print_msg(f"\t{dep_name:<{PKG_NAME_OFFSET}} is in the blacklist", prefix=False, log=_log)
+                        print_msg(f"{' ' * 4 * depth}{dep_name:<{PKG_NAME_OFFSET}} is in the blacklist", prefix=False, log=_log)
 
                     is_excluded = True
                     break
@@ -540,6 +540,7 @@ def _get_R_extension_dependencies(ext, bioconductor_version=None, exclude_list=[
             for proc_ext in processed_exts:
                 if proc_ext.lower() == dep_name.lower():
                     is_processed = True
+                    print_msg(f"{' ' * 4 * depth}{dep_name:<{PKG_NAME_OFFSET}} is already processed", prefix=False, log=_log)
                     break
 
             if is_processed:
@@ -548,7 +549,7 @@ def _get_R_extension_dependencies(ext, bioconductor_version=None, exclude_list=[
             # append the extension to the list of processed extensions
             processed_exts.append(dep_name)
 
-            print_msg(f"{'├──' * (depth-1)}└──{dep_name}", prefix=False, log=_log)
+            print_msg(f"{' ' * 4 * depth}{dep_name:<{PKG_NAME_OFFSET}} added as dependency", prefix=False, log=_log)
 
             # build the metadata dependency as extension getting the last version
             dep = {'name': dep_name, 'version': None, 'options': {}}
@@ -673,7 +674,7 @@ def _get_R_dependency_graph(exts_list, bioconductor_version=None, exclude_list=[
         print_msg("%s" % ext_name, prefix=False, log=_log)
 
         # get dependencies of the extension
-        dependencies = _get_R_extension_dependencies(ext, bioconductor_version, exclude_list)
+        dependencies = _get_R_extension_dependencies(ext, bioconductor_version, exclude_list, processed_exts=nodes)
 
         # append the extension to the list of nodes
         nodes.append(ext_name)

--- a/easybuild/framework/easyconfig/exts_tools.py
+++ b/easybuild/framework/easyconfig/exts_tools.py
@@ -526,8 +526,6 @@ def _get_completed_R_exts_list(exts_list, bioconductor_version=None, installed_e
     # check if the exts_list is empty
     if not exts_list:
         raise EasyBuildError("No exts_list provided for completing")
-    
-    print_msg("Searching for dependencies of the extensions...", log=_log)
 
     # get the dependendy tree. i.e. list of dependencies for each extension
     dependendy_tree = []
@@ -1105,7 +1103,7 @@ def complete_exts_list(ecs):
         print_msg(f"{'local_biocver not set. Bioconductor packages will not be considered' if not bioconductor_version else bioconductor_version}", prefix=False, log=_log)
 
         # get a new exts_list with all extensions to their latest version.
-        print_msg("Completing extension list...", log=_log)
+        print_msg("Searching for dependencies of the extensions...", log=_log)
         completed_exts_list = _get_completed_exts_list(exts_list, exts_defaultclass, installed_exts, bioconductor_version)
 
         # get new easyconfig file with the updated extensions list

--- a/easybuild/framework/easyconfig/exts_tools.py
+++ b/easybuild/framework/easyconfig/exts_tools.py
@@ -510,9 +510,6 @@ def _get_R_extension_dependencies(extension, bioconductor_version=None, exts_lis
             # clean the dependency values
             dep_name, _, _ = _get_clean_pkg_values(dep_name)
 
-            # append the actual dependency to the list
-            dependencies.append((dep_name, ext_name))
-
             # check if the dependency already processed
             is_processed = False
             for proc_ext in processed_exts:
@@ -568,6 +565,9 @@ def _get_R_extension_dependencies(extension, bioconductor_version=None, exts_lis
 
             # append the recursive found dependencies to the list
             dependencies.extend(deps)
+
+            # append the actual dependency to the list
+            dependencies.append((dep_name, ext_name))
 
     return dependencies
 

--- a/easybuild/framework/easyconfig/exts_tools.py
+++ b/easybuild/framework/easyconfig/exts_tools.py
@@ -470,18 +470,6 @@ def _get_R_extension_dependencies(extension, bioconductor_version=None, exts_lis
             if is_in_exts_list:
                 continue
 
-            # check if the dependency is in the exclude list
-            is_excluded = False
-            for exclude_ext in EXCLUDE_R_LIST:
-                if exclude_ext.lower() == dep_name.lower():
-                    is_excluded = True
-                    print_msg(f"\t{dep_name:<{PKG_NAME_OFFSET}} is blacklisted", prefix=False, log=_log)
-                    continue
-
-            # if the dependency is excluded, then skip
-            if is_excluded:
-                continue
-
             # check if the dependency is already installed by a dependency
             is_installed = False
             for inst_ext in installed_exts:
@@ -494,6 +482,18 @@ def _get_R_extension_dependencies(extension, bioconductor_version=None, exts_lis
 
             # if the dependency is already installed, then skip
             if is_installed:
+                continue
+
+            # check if the dependency is in the exclude list
+            is_excluded = False
+            for exclude_ext in EXCLUDE_R_LIST:
+                if exclude_ext.lower() == dep_name.lower():
+                    is_excluded = True
+                    print_msg(f"\t{dep_name:<{PKG_NAME_OFFSET}} is blacklisted", prefix=False, log=_log)
+                    continue
+
+            # if the dependency is excluded, then skip
+            if is_excluded:
                 continue
 
             print_msg(f"\t{dep_name:<{PKG_NAME_OFFSET}} added as dependency", prefix=False, log=_log)
@@ -554,7 +554,7 @@ def _fulfill_exts_list(pkg_class, exts_list, bioconductor_version=None):
 
     if not pkg_class:
         raise EasyBuildError("No package class provided to fulfill the exts_list")
-    
+
     if not exts_list:
         raise EasyBuildError("No exts_list provided to fulfill")
 
@@ -592,7 +592,7 @@ def _delete_duplicated_extensions(exts_list):
 
     :return: list of extensions without duplicates
     """
- 
+
     if not exts_list:
         raise EasyBuildError("No exts_list provided to delete duplicates")
 
@@ -622,6 +622,7 @@ def _delete_duplicated_extensions(exts_list):
         cleaned_exts_list.append(ext)
 
     return cleaned_exts_list
+
 
 def _get_completed_R_exts_list(exts_list, bioconductor_version=None, installed_exts=[]):
     """
@@ -688,10 +689,10 @@ def _get_completed_exts_list(exts_list, exts_defaultclass, installed_exts, bioco
     if exts_defaultclass == "RPackage":
         # get the full list of extensions with their dependencies
         completed_exts_list = _get_completed_R_exts_list(exts_list, bioconductor_version, installed_exts)
-        
+
         # remove duplicated extensions
         cleaned_exts_list = _delete_duplicated_extensions(completed_exts_list)
-        
+
         # fulfill the exts_list with the version and checksums of the extensions
         final_exts_list = _fulfill_exts_list(exts_defaultclass, cleaned_exts_list, bioconductor_version)
 

--- a/easybuild/framework/easyconfig/exts_tools.py
+++ b/easybuild/framework/easyconfig/exts_tools.py
@@ -32,6 +32,7 @@ Authors:
 * Danilo Gonzalez (Do IT Now)
 """
 
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from collections import deque
 import hashlib
 import re
@@ -78,15 +79,15 @@ _log = fancylogger.getLogger('easyblock')
 def _create_graph(edges, nodes):
     """
     Create a graph from the given edges and nodes.
-    
+
     :param edges: list of edges
     :param nodes: list of nodes
-    
+
     :return: graph
     """
     # initialize graph
     graph = {"nodes": set(), "edges": {}}
-    
+
     # Add dependencies (edges) to the graph
     for from_node, to_node in edges:
         if from_node not in graph["nodes"]:
@@ -96,7 +97,7 @@ def _create_graph(edges, nodes):
             graph["nodes"].add(to_node)
             graph["edges"][to_node] = []
         graph["edges"][from_node].append(to_node)
-    
+
     # Add standalone nodes
     if nodes:
         for node in nodes:
@@ -110,9 +111,9 @@ def _create_graph(edges, nodes):
 def _topological_sort(graph):
     """
     Perform a topological sort of the given graph.
-    
+
     :param graph: graph to sort
-    
+
     :return: sorted list of the graph
     """
 
@@ -486,7 +487,7 @@ def _get_R_extension_dependencies(ext, bioconductor_version=None, exclude_list=[
     # if the extension is a string, then skip further processing
     if isinstance(ext, str):
         return []
-    
+
     # init variables
     dependencies = []
 
@@ -517,7 +518,14 @@ def _get_R_extension_dependencies(ext, bioconductor_version=None, exclude_list=[
             # if the dependency is in the exclude list, then skip
             is_excluded = False
             for excluded_ext in exclude_list:
-                if excluded_ext.lower() == dep_name.lower():
+                excluded_name, _ , excluded_options = _get_extension_values(excluded_ext)
+                if excluded_name.lower() == dep_name.lower():
+                    ec_path = excluded_options.get('easyconfig_path', None)
+                    if ec_path:
+                        print_msg(f"\t{dep_name:<{PKG_NAME_OFFSET}} is already installed by '{ec_path}'", prefix=False, log=_log)
+                    else:
+                        print_msg(f"\t{dep_name:<{PKG_NAME_OFFSET}} is in the blacklist", prefix=False, log=_log)
+
                     is_excluded = True
                     break
 
@@ -706,7 +714,7 @@ def _get_completed_exts_list(exts_list, exts_defaultclass, installed_exts, bioco
 
     if exts_defaultclass == "RPackage":
         # build the exclude list
-        exclude_list = EXCLUDE_R_LIST + [ext[0] for ext in installed_exts]
+        exclude_list = installed_exts + [(ex, '', {}) for ex in EXCLUDE_R_LIST]
 
         # get the dependency graph of the extensions
         dep_graph = _get_R_dependency_graph(exts_list, bioconductor_version, exclude_list)
@@ -1024,81 +1032,128 @@ def _crosscheck_exts_list(exts_list, installed_exts):
         print_msg("No pre-installed extensions found in the exts_list!\n", log=_log)
 
 
-def _get_installed_exts(ec, ec_dep=None, processed_deps=[]):
+def _get_deps_and_exts(ec_name):
     """
-    Generate a list of extensions that will be pre-installed due to dependencies or build_dependencies specified in the easyconfig parameters.
+    Get the dependencies, build dependencies and extensions of the given EasyConfig name.
 
-    :param ec: original EasyConfig instance to retrieve extensions from
-    :param ec_dep: dependency EasyConfig instance to retrieve extensions from
-    :param processed_deps: list of processed dependencies
+    :param ec_name: name of the EasyConfig instance to get dependencies and extensions from
+
+    :return: list of EasyConfig dependencies and list of extensions
+    """
+
+    # init variables
+    deps = []
+    exts = []
+
+    # search for the corresponding EasyConfig file
+    easyconfigs = search_easyconfigs(ec_name, print_result=False)
+
+    # if easyconfig files were found, then process them
+    if not easyconfigs:
+        print_warning("No EasyConfig file found for dependency %s", ec_name)
+        return (ec_name, deps, exts)
+
+    # print warning if more than one EasyConfig file was found
+    if len(easyconfigs) > 1:
+        print_warning("More than one EasyConfig file found for dependency %s: %s", ec_name, easyconfigs)
+
+    # process the EasyConfig file
+    ec = process_easyconfig(easyconfigs[0], validate=False)[0]
+
+    # get the dependencies of the given EasyConfig
+    ec_deps = _get_dependencies(ec)
+
+    # process the dependencies of the EasyConfig to get only the name of the dependency
+    for dep in ec_deps:
+
+        # get dependency's name
+        dep_name = dep['full_mod_name'].replace('/', '-') + ".eb"
+
+        # If dependency is a system dependency, store it as an extension being installed and skip futher processing
+        if dep['system']:
+            exts.append((dep['name'], dep['version'], {'easyconfig_path': ec['spec']}))
+            continue
+
+        # add the dependency to the list of dependencies
+        deps.append(dep_name)
+
+    # get the extensions of the EasyConfig
+    exts_list = _get_exts_list(ec)
+    for ext in exts_list:
+        ext_name, ext_version, ext_options = _get_extension_values(ext)
+        ext_options['easyconfig_path'] = ec['spec']
+        exts.append((ext_name, ext_version, ext_options))
+
+    return (ec_name, deps, exts)
+
+
+def _get_installed_exts(ec):
+    """
+    Get the list of extensions that will be installed due to dependencies or build_dependencies of the given EasyConfig. It will also process the dependencies of the dependencies.
+
+    :param ec: EasyConfig instance to retrieve extensions from
+
+    :return: list of extensions installed by the given EasyConfig
     """
 
     if not ec:
         raise EasyBuildError("No EasyConfig instance provided to retrieve extensions from")
 
-    print_msg(f"\r\tDependencies processed: {len(processed_deps)}", newline=False, prefix=False, log=_log)
-
-    # init variable to store the installed extensions
-    installed_exts = []
-
-    # if ec_dep is provided, then get the dependencies of the dependency
-    # else get dependencies of the original EasyConfig
-    if ec_dep:
-        dependencies = _get_dependencies(ec_dep)
-    else:
-        dependencies = _get_dependencies(ec)
-
     # set terse mode to True to avoid printing unnecessary information
     terse = build_option('terse')
     update_build_option('terse', True)
 
-    # get the extensions of the dependencies of the current EasyConfig
-    for dep in dependencies:
+    # init variables
+    processed_deps = set()
+    dependencies = []
+    installed_exts = []
+    futures = []
 
-        # get dependency's name
+    # get the dependencies of the original EasyConfig
+    deps = _get_dependencies(ec)
+    for dep in deps:
         dep_name = dep['full_mod_name'].replace('/', '-') + ".eb"
+        dependencies.append(dep_name)
 
-        # check if dependency was already processed. If so, skip it
-        if dep_name in processed_deps:
-            continue
+    # process the dependency tree of the EasyConfig in parallel
+    with ProcessPoolExecutor() as executor:
 
-        # add dependency to the list of processed dependencies
-        processed_deps.append(dep_name)
+        # keep processing while there are dependencies to be processed or futures being processed
+        while dependencies or futures:
 
-        # If dependency is a system dependency, store it as an extension being installed and skip futher processing
-        if dep['system']:
-            installed_exts.extend([{'name': dep['name'], 'version': dep['version']}])
-            continue
+            # process the dependencies pending to be processed
+            for dep_name in dependencies:
 
-        # search for the corresponding EasyConfig file
-        easyconfigs = search_easyconfigs(dep_name, print_result=False)
+                # process the dependency if it has not been processed yet
+                if dep_name not in processed_deps:
 
-        # if easyconfig files were found, then process them
-        if easyconfigs:
+                    # add the EasyConfig to the list of processed dependencies
+                    processed_deps.add(dep_name)
 
-            # print warning if more than one EasyConfig file was found
-            if len(easyconfigs) > 1:
-                print_warning("More than one EasyConfig file found for dependency %s: %s", dep_name, easyconfigs)
+                    print_msg(f"\r\tDependencies processed: {len(processed_deps)}",
+                              newline=False, prefix=False, log=_log)
 
-            # process only the first EasyConfig file found
-            easyconfig_dep = process_easyconfig(easyconfigs[0], validate=False)[0]
+                    # submit the EasyConfig dependency instance to the executor
+                    futures.append(executor.submit(_get_deps_and_exts, dep_name))
 
-            # Search recursively for pre-installed extensions of dependencies of the current EasyConfig
-            installed = _get_installed_exts(ec, easyconfig_dep, processed_deps)
+                # remove the dependency from the list
+                dependencies.remove(dep_name)
 
-            # store the extensions of the dependencies of the current EasyConfig
-            for ext in installed:
-                ext_name, ext_version, ext_options = _get_extension_values(ext)
-                ext_options['easyconfig_path'] = easyconfig_dep['spec']
-                installed_exts.append((ext_name, ext_version, ext_options))
+            # completed dependencies processing
+            for future in as_completed(futures):
+                # get the result of the future
+                _, deps, exts = future.result()
 
-    # get and store the extensions of the current EasyConfig only if it is a dependency
-    # avoid storing extensions of the original EasyConfig
-    if ec_dep:
-        for ext in _get_exts_list(ec_dep):
-            ext_name, ext_version, ext_options = _get_extension_values(ext)
-            ext_options['easyconfig_path'] = ec_dep['spec']
-            installed_exts.append((ext_name, ext_version, ext_options))
+                # store the Easyconfig dependencies
+                for dep in deps:
+                    if dep not in processed_deps:
+                        dependencies.append(dep)
+
+                # store the extensions installed by the dependencies
+                installed_exts.extend(exts)
+
+                # remove the future from the list
+                futures.remove(future)
 
     # restore the original value of the terse option
     update_build_option('terse', terse)

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -55,7 +55,7 @@ from easybuild.framework.easyconfig import easyconfig
 from easybuild.framework.easystack import parse_easystack
 from easybuild.framework.easyconfig.easyconfig import clean_up_easyconfigs
 from easybuild.framework.easyconfig.easyconfig import fix_deprecated_easyconfigs, verify_easyconfig_filename
-from easybuild.framework.easyconfig.exts_tools import complete_exts_list, update_exts_list, update_exts_list
+from easybuild.framework.easyconfig.exts_tools import complete_exts_list, update_exts_list, check_exts_list
 from easybuild.framework.easyconfig.style import cmdline_easyconfigs_style_check
 from easybuild.framework.easyconfig.tools import categorize_files_by_type, dep_graph, det_copy_ec_specs
 from easybuild.framework.easyconfig.tools import det_easyconfig_paths, dump_env_script, get_paths_for

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -55,7 +55,7 @@ from easybuild.framework.easyconfig import easyconfig
 from easybuild.framework.easystack import parse_easystack
 from easybuild.framework.easyconfig.easyconfig import clean_up_easyconfigs
 from easybuild.framework.easyconfig.easyconfig import fix_deprecated_easyconfigs, verify_easyconfig_filename
-from easybuild.framework.easyconfig.exts_tools import update_exts_list, check_installed_exts
+from easybuild.framework.easyconfig.exts_tools import complete_exts_list, update_exts_list, check_installed_exts
 from easybuild.framework.easyconfig.style import cmdline_easyconfigs_style_check
 from easybuild.framework.easyconfig.tools import categorize_files_by_type, dep_graph, det_copy_ec_specs
 from easybuild.framework.easyconfig.tools import det_easyconfig_paths, dump_env_script, get_paths_for
@@ -552,6 +552,11 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
         dep_graph(options.dep_graph, ordered_ecs)
         return True
 
+    # complete exts_list extensions list and exit
+    elif options.complete_exts_list:
+        complete_exts_list(ordered_ecs)
+        return True
+    
     # update all extensions in exts_list to the latest version and exit
     if options.update_exts_list:
         update_exts_list(ordered_ecs)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -693,6 +693,7 @@ class EasyBuildOptions(GeneralOption):
             'show-full-config': ("Show current EasyBuild configuration (all settings)", None, 'store_true', False),
             'show-system-info': ("Show system information relevant to EasyBuild", None, 'store_true', False),
             'terse': ("Terse output (machine-readable)", None, 'store_true', False),
+            'complete-exts-list': ("Complete the exts_list of an easyconfig file", None ,'store_true', False),  
             'update-exts-list': ("Update the exts_list of an easyconfig file", None, 'store_true', False),
             'check-installed-exts': ("Check if an extensions is already being installed by a dependency", None, 'store_true', False),
             'easystack': ("Path to easystack file in YAML format, specifying details of a software stack",


### PR DESCRIPTION
Completes the exts_list for R packages adding dependencies on top of the extensions to avoid build issues. 
Extensions installed by dependencies or build_dependencies are ignored. 
Blacklisted extensions, such as base R packages, are ignored too.
Example of output:

```
COMPLETE EASYCONFIG EXTENSIONS
== Easyconfig: /home/vmachado/projects/easybuild/easyconfigs/bioconductor/BgeeCall-1.16.0-foss-2021a-R-4.1.0.eb
== Getting extension list: 6 extensions found.
== Getting extension's class: RPackage
== Getting extensions installed by dependencies or build dependencies...
        Dependencies processed: 119     Installed extensions found: 1801
== Getting Bioconductor version: local_biocver not set. Bioconductor packages will not be considered
== Completing extension list...
== Searching for dependencies of the extensions...

== Dependencies of 'insight':
        R                  is blacklisted
        methods            is blacklisted
        stats              is blacklisted
        utils              is blacklisted

== Dependencies of 'datawizard':
        insight            is in the original exts_list. RECOMMENDATION: Consider removing insight from the original exts_list

== Dependencies of 'sjlabelled':
        datawizard         is in the original exts_list. RECOMMENDATION: Consider removing datawizard from the original exts_list
        tools              is blacklisted

== Dependencies of 'sjmisc':
        dplyr              installed by dependency: /home/vmachado/projects/easybuild/easybuild-framework_2024/.venv/easybuild/easyconfigs/r/R/R-4.1.0-foss-2021a.eb
        magrittr           installed by dependency: /home/vmachado/projects/easybuild/easybuild-framework_2024/.venv/easybuild/easyconfigs/r/R/R-4.1.0-foss-2021a.eb
        purrr              installed by dependency: /home/vmachado/projects/easybuild/easybuild-framework_2024/.venv/easybuild/easyconfigs/r/R/R-4.1.0-foss-2021a.eb
        rlang              installed by dependency: /home/vmachado/projects/easybuild/easybuild-framework_2024/.venv/easybuild/easyconfigs/r/R/R-4.1.0-foss-2021a.eb
        sjlabelled         is in the original exts_list. RECOMMENDATION: Consider removing sjlabelled from the original exts_list
        tidyselect         installed by dependency: /home/vmachado/projects/easybuild/easybuild-framework_2024/.venv/easybuild/easyconfigs/r/R/R-4.1.0-foss-2021a.eb

== Dependencies of 'rslurm':
        whisker            installed by dependency: /home/vmachado/projects/easybuild/easybuild-framework_2024/.venv/easybuild/easyconfigs/r/R/R-4.1.0-foss-2021a.eb

== Dependencies of 'BgeeCall':

== List of extensions with their dependencies on top...
        insight            v0.19.3    
        datawizard         v0.8.0     
        sjlabelled         v1.2.0     
        sjmisc             v2.8.9     
        rslurm             v0.6.2     
        BgeeCall           v1.16.0    

== Updating Easyconfig instance with completed exts_list...
== Backing up EasyConfig file at /home/vmachado/projects/easybuild/easyconfigs/bioconductor/BgeeCall-1.16.0-foss-2021a-R-4.1.0.eb.bak_update_20241127125425_134413
== Writing updated EasyConfig file...
EASYCONFIG SUCCESSFULLY COMPLETED!
```
